### PR TITLE
[codex] Add Chrome Web Store link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Greeat
+
+[Chrome Web Store](https://chromewebstore.google.com/detail/ibpohnoiihccbcjefnnnghnkipnnhpij)


### PR DESCRIPTION
## Summary
- add a minimal README at the repository root
- include the Chrome Web Store link for the published extension

## Why
- make the install destination visible directly from the repository
- provide a simple landing page for visitors before adding fuller documentation

## Impact
- repository visitors can reach the Chrome Web Store listing from GitHub
- no runtime or extension behavior changes

## Testing
- not run (documentation-only change)